### PR TITLE
Update the Dockerfile for legacy-gpu

### DIFF
--- a/legacy-gpu/Dockerfile
+++ b/legacy-gpu/Dockerfile
@@ -1,27 +1,40 @@
-FROM tensorflow/tensorflow:latest-gpu-py3
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu20.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+
+# install python 3.10 and curl
+RUN apt update && \
+    apt install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt update && \
+    apt install -y python3.10 python3.10-venv python3.10-dev curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# install pip for python 3.10
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+
+# install dependencies
 RUN pip install --upgrade pip
 RUN pip install \
-        theano==1.0.5 \
-        Cython==0.29.21 \
-        numpy==1.18.1 \
-        matplotlib==3.3.1 \
-        seaborn==0.10.1 \
-        scipy==1.4.1 \
-        scikit-learn==0.23.2 \
-        pandas==1.1.0 \
-        pyyaml==5.3.1 \
-        imutils \
-        opencv-python \
-        torch==1.6.0 \
-        tqdm==4.48.2 \
-        psutil==5.7.2 \
-        h5py==2.10.0 \
-        jupyter
+                Cython==3.0.10 \
+                numpy==1.26.4 \
+                matplotlib==3.9.0 \
+                seaborn==0.13.2 \
+                scipy==1.14.0 \
+                scikit-learn==1.5.0 \
+                pandas==2.2.2 \
+                PyYAML==6.0.1 \
+                imutils==0.5.4 \
+                opencv-python==4.10.0.84 \
+                torch==2.3.1 \
+                tensorflow==2.16.1 \
+                tqdm==4.66.4 \
+                psutil==6.0.0 \
+                h5py==3.11.0 \
+                jupyter==1.0.0 &&\
+                rm -rf ~/.cache/pip
+
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /app/codalab
-
-# To add
-# apt-get update
-# apt-get -y install libgl1-mesa-glx
-# apt-get -y install libglb2.0-0

--- a/legacy-gpu/Dockerfile
+++ b/legacy-gpu/Dockerfile
@@ -2,21 +2,22 @@ FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# install python 3.10 and curl
+# install python 3.10
 RUN apt update && \
     apt install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt update && \
     apt install -y python3.10 python3.10-venv python3.10-dev curl && \
+    ln -sf /usr/bin/python3.10 /usr/bin/python3 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# install pip for python 3.10
+# install pip
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 
 # install dependencies
-RUN pip install --upgrade pip
-RUN pip install \
+RUN python3 -m pip install pip --upgrade && \
+    python3 -m pip install \
                 Cython==3.0.10 \
                 numpy==1.26.4 \
                 matplotlib==3.9.0 \

--- a/legacy-gpu/README.md
+++ b/legacy-gpu/README.md
@@ -1,6 +1,6 @@
 # Docker image for submissions sent on GPU workers
 
-* Based on `tensorflow/tensorflow:latest-gpu-py3`
+* Based on `nvidia/cuda:12.4.1-cudnn-runtime-ubuntu20.04`
 * Common Python librairies
 
 The associated DockerHub image is `codalab/codalab-legacy:gpu`


### PR DESCRIPTION
Updated the Dockerfile for the legacy-gpu based on nvidia/cuda:12.4.1 to use Ubuntu 20.04, CUDA 12.4.1, Python 3.10 and newer versions of common Python libraries for GPU applications

Compared to the previous Dockerfile, I use a base image from nvidia/cuda instead of tensorflow/tensorflow to get a lighter image (11.3GB instead of 16.2 when using the tensorflow/tensorflow:latest-gpu). This choice makes it that Python is not pre-installed in the base image and needs to be installed. Chose Python 3.10 but 3.9 could be used with the versions of Python libraries specified.

I believe that this Dockerfile cannot be used to generate a Docker image that would work on the current codalab workers due to there older version of CUDA.

The choices of version of Ubuntu, CUDA, Python and Python libraries are open for discussion.